### PR TITLE
Add the processing command related to the migration content of `[TechnoType] -> WarpAway`

### DIFF
--- a/MigrationUtility/Scripts/UpdatePhobosTags.sed
+++ b/MigrationUtility/Scripts/UpdatePhobosTags.sed
@@ -1,6 +1,11 @@
 # reference: https://www.gnu.org/software/sed/manual/sed.html#sed-scripts
 # regexp playground (syntax may differ a bit): https://regexr.com
 
+# from 0.4
+# =============================================
+s/^WarpAway=/Chronoshift\.WarpOut=/I
+/^\[General\]/,/^\[/ s/Chronoshift\.WarpOut=/WarpAway=/I
+
 # from post-0.3 devbuilds
 # =============================================
 s/^AnimList\.ShowOnZeroDamage=/CreateAnimsOnZeroDamage=/I


### PR DESCRIPTION
> [!NOTE]
> Although the second command, which is used to avoid `[General] -> WarpAway` from being incorrectly changed, has some differences in writing compared to our previous commands, it has already run and passed verification in relatively complex input situations.

Example:

- putin:
```ini
;xxxx
; WarpAway
; Chronoshift.WarpOut
[CCOMAND]
WarpAway=IONBEAM
; Suppose that the user, due to writing habits or the order in which content is added in an included INI file being affected by temporal sequence, among other reasons, has placed a unit section here before [General].
[General]
WarpAway=WARPAWAY;RING1		; animation when warping something out of existance
; Global
[CLEG]
WarpAway=WCCLOUD1 ; minor, WarpAway
; Techno#1
[CIVAN]
WarpAway=MININUKE ; KBOOOM, Chronoshift.WarpOut
; Techno#2
```

- putout:
```ini
;xxxx
; WarpAway
; Chronoshift.WarpOut
[CCOMAND]
Chronoshift.WarpOut=IONBEAM
; Suppose that the user, due to writing habits or the order in which content is added in an included INI file being affected by temporal sequence, among other reasons, has placed a unit section here before [General].
[General]
WarpAway=WARPAWAY;RING1		; animation when warping something out of existance
; Global
[CLEG]
Chronoshift.WarpOut=WCCLOUD1 ; minor, WarpAway
; Techno#1
[CIVAN]
Chronoshift.WarpOut=MININUKE ; KBOOOM, Chronoshift.WarpOut
; Techno#2
```

## Actual Effect
- before:
```ini
[TNKD]
Locomotor=Teleport
WarpIn=MININUKE
WarpOut=WCCLOUD1
WarpAway=RING1
```
<img width="584" height="308" alt="WarpAway" src="https://github.com/user-attachments/assets/d7a1d9c2-38a8-4815-b8ef-c5039b7f48b8" />

- after:
```ini
[TNKD]
Locomotor=Teleport
WarpIn=MININUKE
WarpOut=WCCLOUD1
Chronoshift.WarpOut=RING1
Chronoshift.WarpIn=PDFXLOC
```
<img width="639" height="368" alt="Chronoshift WarpOut" src="https://github.com/user-attachments/assets/a8259536-f1ab-4921-acfe-1e53ae0f9cea" />
